### PR TITLE
More options for project id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.2] - 2023-08-14
+## [0.0.2] - 2023-08-20
 
 ### Added
 Working specs
 Auth using Google Auth
+Project using Google::Cloud.env
 
 ## [0.0.1] - 2023-08-01
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ gem "rubocop", "~> 1.50.2"
 gem "vcr", "~> 6.1.0"
 gem "webmock", "~> 3.18.1"
 gem "googleauth"
+gem 'google-cloud-env'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    google-cloud-llm (0.0.1)
+    google-cloud-llm (0.0.2)
       faraday (>= 1)
       faraday-multipart (>= 1)
       googleauth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,8 @@ GEM
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
+    google-cloud-env (1.6.0)
+      faraday (>= 0.17.3, < 3.0)
     googleauth (1.7.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
@@ -90,6 +92,7 @@ PLATFORMS
 DEPENDENCIES
   byebug (~> 11.1.3)
   dotenv (~> 2.8.1)
+  google-cloud-env
   google-cloud-llm!
   googleauth
   rake (~> 13.0)

--- a/lib/google/cloud/llm.rb
+++ b/lib/google/cloud/llm.rb
@@ -1,6 +1,7 @@
 require "faraday"
 require "faraday/multipart"
 require "googleauth"
+require "google/cloud/env"
 
 require_relative "llm/http"
 require_relative "llm/client"
@@ -57,7 +58,8 @@ module Google
 
         def project_id
           return @project_id if @project_id
-          return @google_auth.project_id if google_auth
+          return @google_auth.project_id if google_auth.project_id
+          return Google::Cloud.env.project_id if Google::Cloud.env.project_id
 
           error_text = "Google::Cloud::LLM project_id missing! See https://github.com/alexrudall/ruby-gcp-llm#usage"
           raise ConfigurationError, error_text

--- a/lib/google/cloud/llm/version.rb
+++ b/lib/google/cloud/llm/version.rb
@@ -1,7 +1,7 @@
 module Google
   module Cloud
     module LLM
-      VERSION = "0.0.1".freeze
+      VERSION = "0.0.2".freeze
     end
   end
 end

--- a/spec/google-cloud-llm_spec.rb
+++ b/spec/google-cloud-llm_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Google::Cloud::LLM do
       Google::Cloud::LLM.configure do |config|
         config.access_token = access_token
         config.project_id = project_id
-        # config.organization_id = organization_id
       end
     end
 
@@ -27,16 +26,6 @@ RSpec.describe Google::Cloud::LLM do
       expect(Google::Cloud::LLM.configuration.uri_base).to eq(standard_uri_base)
       expect(Google::Cloud::LLM.configuration.request_timeout).to eq(120)
     end
-
-    # context "without an access token" do
-    #   let(:access_token) { nil }
-
-    #   it "raises an error" do
-    #     expect do
-    #       Google::Cloud::LLM::Client.new.completions
-    #     end.to raise_error(Google::Cloud::LLM::ConfigurationError)
-    #   end
-    # end
 
     context "with custom timeout and uri base" do
       before do

--- a/spec/google/cloud/llm/configuration_spec.rb
+++ b/spec/google/cloud/llm/configuration_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Google::Cloud::LLM::Configuration do
+  subject { described_class.new }
+
+  describe "#project_id" do
+    let(:config) { Google::Cloud::LLM::Configuration.new }
+    let(:fake_google_auth) { double("Google::Auth", project_id: fake_google_auth_project_id) }
+    let(:fake_google_auth_project_id) { "auth_project_id" }
+
+    before do
+      # Stubbing external dependencies
+      allow(Google::Auth).to receive(:get_application_default).and_return(fake_google_auth)
+      allow(Google::Cloud.env).to receive(:project_id).and_return(nil) # Default to nil
+    end
+
+    context "when @project_id is set" do
+      it "returns @project_id" do
+        subject.project_id = "explicit_project_id"
+        expect(subject.project_id).to eq("explicit_project_id")
+      end
+    end
+
+    context "when google_auth has a project_id" do
+      it "returns the google_auth project_id" do
+        expect(subject.project_id).to eq("auth_project_id")
+      end
+    end
+
+    context "when Google::Cloud.env.project_id is present" do
+      let(:fake_google_auth_project_id) { nil }
+
+      before do
+        allow(Google::Cloud.env).to receive(:project_id).and_return("cloud_env_project_id")
+      end
+
+      it "returns the Google::Cloud.env.project_id" do
+        expect(subject.project_id).to eq("cloud_env_project_id")
+      end
+    end
+
+    context "when no project_id is available" do
+      let(:fake_google_auth) { double("Google::Auth", project_id: nil) }
+      before do
+        allow(Google::Cloud.env).to receive(:project_id).and_return(nil)
+      end
+
+      it "raises a ConfigurationError" do
+        expect { subject.project_id }.to raise_error(Google::Cloud::LLM::ConfigurationError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In GCP environments. auth may not return the project ID, but another library can. Add this, and some tests to check the order

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
